### PR TITLE
[-] Fix encoding and locale

### DIFF
--- a/src/Memcadmin.php
+++ b/src/Memcadmin.php
@@ -36,19 +36,13 @@ class Memcadmin_Application {
 
 		ini_set('display_errors', 1);
 		error_reporting(E_ALL);
+		ini_set("default_charset", "UTF-8");
 
 		ini_set("mbstring.language", "Neutral");
-		@ini_set("mbstring.internal_encoding", "UTF-8");
 		ini_set("mbstring.encoding_translation", "On");
-		@ini_set("mbstring.http_input", "auto");
-		@ini_set("mbstring.http_output", "UTF-8");
 		ini_set("mbstring.detect_order", "auto");
 		ini_set("mbstring.substitute_character", "none");
-		ini_set("default_charset", "UTF-8");
 		ini_set("mbstring.func_overload", 7);
-
-		setlocale(LC_TIME, "de_DE.UTF-8");
-		date_default_timezone_set("Europe/Vienna");
 
 		header("Cache-Control: no-store, no-cache, must-revalidate");
 		header("Cache-Control: post-check=0, pre-check=0", false);


### PR DESCRIPTION
- don't set `mbstring_*`
- set `default_charset` "UTF-8"
- don't hard set a `locale` (it is sysadmin responsibility, `.htaccess` can be a way)